### PR TITLE
Execute as if in `__main__`

### DIFF
--- a/mktestdocs/__main__.py
+++ b/mktestdocs/__main__.py
@@ -40,7 +40,7 @@ def exec_python(source):
     will propagate out unmodified
     """
     try:
-        exec(source, {"__MODULE__": "__main__"})
+        exec(source, {"__name__": "__main__"})
     except Exception:
         print(source)
         raise


### PR DESCRIPTION
`__MODULE__` seems like a mistake since that's not a known global attribute of modules.