### PR TITLE
Support examples in hf-doc-builder docs

### DIFF
--- a/mktestdocs/__main__.py
+++ b/mktestdocs/__main__.py
@@ -50,7 +50,7 @@ register_executor("", exec_python)
 register_executor("python", exec_python)
 
 
-def get_codeblock_members(*classes):
+def get_codeblock_members(*classes, lang="python"):
     """
     Grabs the docstrings of any methods of any classes that are passed in.
     """
@@ -61,7 +61,7 @@ def get_codeblock_members(*classes):
         for name, member in inspect.getmembers(cl):
             if member.__doc__:
                 results.append(member)
-    return [m for m in results if len(grab_code_blocks(m.__doc__)) > 0]
+    return [m for m in results if len(grab_code_blocks(m.__doc__, lang=lang)) > 0]
 
 
 def check_codeblock(block, lang="python"):
@@ -76,7 +76,7 @@ def check_codeblock(block, lang="python"):
     """
     first_line = block.split("\n")[0]
     if lang:
-        if first_line[3:] != lang:
+        if first_line.lstrip()[3:] != lang:
             return ""
     return "\n".join(block.split("\n")[1:])
 
@@ -104,11 +104,13 @@ def grab_code_blocks(docstring, lang="python"):
             block += line + "\n"
     return [textwrap.dedent(c) for c in codeblocks if c != ""]
 
+
 def format_docstring(docstring):
     """Formats docstring to be able to successfully go through dedent."""
     if docstring[:1] != "\n":
         return f"\n    {docstring}"
     return docstring
+
 
 def check_docstring(obj, lang=""):
     """

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -60,12 +60,27 @@ class Dinosaur:
         """
         return self.name
 
+    def hfdocs_style(self, value):
+        """
+        Returns value
+
+        Example:
+
+            ```python
+            from dinosaur import Dinosaur
+
+            dino = Dinosaur()
+            assert dino.a(1) == 1
+            ```
+        """
+        return value
+
 
 members = get_codeblock_members(Dinosaur)
 
 
 def test_grab_methods():
-    assert len(get_codeblock_members(Dinosaur)) == 4
+    assert len(get_codeblock_members(Dinosaur)) == 5
 
 
 @pytest.mark.parametrize("obj", members, ids=lambda d: d.__qualname__)

--- a/tests/test_mktestdocs.py
+++ b/tests/test_mktestdocs.py
@@ -2,9 +2,10 @@ import pathlib
 
 from mktestdocs import check_md_file
 
+
 def test_readme(monkeypatch):
     test_dir = pathlib.Path(__file__).parent
     fpath = test_dir.parent / "README.md"
     monkeypatch.chdir(test_dir)
 
-    check_md_file(fpath=fpath)
+    check_md_file(fpath=fpath, memory=True)


### PR DESCRIPTION
Extracting examples from HF doc-builder did not work because they are indented after extraction like

```
Example:
    ```python
    ...
    ```
```

which caused the language check to fail, since it did not take into account that the code block could still be preceded by whitespace.

Incidentally, this also uncovered a bug in testing the README markdown, since this requires `memory=True`, as the README itself describes.